### PR TITLE
change service type to oneshot

### DIFF
--- a/templates/backup.service
+++ b/templates/backup.service
@@ -2,7 +2,7 @@
 Description=Backup Service
 
 [Service]
-Type=simple
+Type=oneshot
 ExecStart=/opt/backup/backup
 ExecStartPost=/opt/backup/cleanup
 User={{ backup_user }}


### PR DESCRIPTION
This patch prevents the ExecStartPost (cleanup) command to start before the backup is finished. 
With the service `Type=simple`, the cleanup is started right after the backup has been started.
With the service `Type=oneshot`, the cleanup starts only when the process exited successfully.

see https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#ExecStartPre=

> ExecStartPost= commands are only run after the commands specified in ExecStart= have been invoked successfully, as determined by Type= (i.e. the process has been started for Type=simple or Type=idle, the last ExecStart= process exited successfully for Type=oneshot, the initial process exited successfully for Type=forking, "READY=1" is sent for Type=notify/Type=notify-reload, or the BusName= has been taken for Type=dbus).

